### PR TITLE
All telescope types can be stored in VECTOR mode

### DIFF
--- a/image_extractor/row_descriptors.py
+++ b/image_extractor/row_descriptors.py
@@ -25,4 +25,5 @@ class Tel(IsDescription):
     tel_z = Float32Col()
     tel_type = StringCol(8)
     run_array_direction = Float32Col(2)
-
+    optical_foclen = Float32Col()
+    num_pixels = UInt8Col()


### PR DESCRIPTION
Arbitrary combinations of telescope types now being stored (given that there
are no duplicated entries in [telescope]type_mode - the code checks for that).
num_pixels and optical_foclen variables now stored into Tel_Table.